### PR TITLE
Fixes to location of PythTB website

### DIFF
--- a/notes/README
+++ b/notes/README
@@ -40,7 +40,7 @@ put in .tar.gz file. of the old version.
 *It is enough to do this for the old version only!*
 You will also have to add that folder to cvs.
 To get old source file use this command:
-wget http://physics.rutgers.edu/pythtb/_downloads/pythtb-X.X.X.tar.gz
+wget http://www.physics.rutgers.edu/pythtb/_downloads/pythtb-X.X.X.tar.gz
 
 5. Update website/source/install.rst with the new version. It is enough to
 change string "1.6.1" with "1.6.2" or similar.

--- a/pythtb.py
+++ b/pythtb.py
@@ -3634,7 +3634,7 @@ def _offdiag_approximation_warning_and_stop():
   operator in the Wannier basis.  This is discussed here in more
   detail:
 
-    http://physics.rutgers.edu/pythtb/usage.html#pythtb.w90
+    http://www.physics.rutgers.edu/pythtb/usage.html#pythtb.w90
 
   If you know what you are doing and wish to continue with the
   calculation despite this approximation, please call the following


### PR DESCRIPTION
Sinisa,

The web environment at Rutgers changed recently. Compare
  http://physics.rutgers.edu/pythtb
  http://www.physics.rutgers.edu/pythtb
It used to be that both got directed to the same place, but now the first link is dead and only the full URL is active. In this revision I've added the 'www.' in two places where it is needed. BTW, I've requested that the shorter URL should be forwarded to the full one, but I'm not sure when or even if it will be done.  Management of http://physics.rutgers.edu is now handled by IT people outside our department, while we only control the longer URLs.

David
