### PR TITLE
Feature fix sphinx

### DIFF
--- a/website/matplotlibrc
+++ b/website/matplotlibrc
@@ -310,7 +310,7 @@ figure.subplot.hspace	: 0.2    # the amount of height reserved for white space b
 # ps backend params
 #ps.papersize      : letter   # auto, letter, legal, ledger, A0-A10, B0-B10
 #ps.useafm         : False    # use of afm fonts, results in small files
-ps.usedistiller   : xpdf    # can be: None, ghostscript or xpdf
+#ps.usedistiller   : xpdf    # can be: None, ghostscript or xpdf
                                           # Experimental: may produce smaller files.
                                           # xpdf intended for production of publication quality files,
                                           # but requires ghostscript, xpdf and ps2eps

--- a/website/source/conf.py
+++ b/website/source/conf.py
@@ -31,12 +31,13 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.imgmath',
               'sphinx.ext.viewcode',
 #              'matplotlib.sphinxext.mathmpl',
-              'matplotlib.sphinxext.only_directives',
+#              'matplotlib.sphinxext.only_directives',
               'matplotlib.sphinxext.plot_directive',
               'ipython_console_highlighting',
 #             'inheritance_diagram',
-              'numpydoc']
-#              'googleanalytics']
+#              'numpydoc']
+#              'googleanalytics'
+]
 
 # for googleanalytics tracking
 googleanalytics_id = 'UA-18832825-1'


### PR DESCRIPTION
conf.py was generated with an old version of sphinx.  The new version of sphinx (and matplotlib) didn't like some of the parameters in that file and they crashed "go" script in the website folder.